### PR TITLE
Dynamically adjust batch size and skip over blank id ranges

### DIFF
--- a/lib/pgsync/client.rb
+++ b/lib/pgsync/client.rb
@@ -102,6 +102,7 @@ module PgSync
       # o.separator "Append-only table options:"
       o.boolean "--in-batches", "sync in batches", default: false, help: false
       o.integer "--batch-size", "batch size", default: 10000, help: false
+      o.integer "--starting-id", "starting id", help: false
       o.float "--sleep", "time to sleep between batches", default: 0, help: false
 
       o.separator ""


### PR DESCRIPTION
Skip over blank id ranges.

Dynamically adjust the batch size in case of sparse ids.

Allow specifying `starting-id` on the command line, primarily for testing.
